### PR TITLE
Fix successful MLX tokenizer loads

### DIFF
--- a/tests/test_tokenizer_utils.py
+++ b/tests/test_tokenizer_utils.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for tokenizer utility helpers."""
+
+import platform
+import sys
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "darwin" or platform.machine() != "arm64",
+    reason="Requires Apple Silicon",
+)
+
+
+class TestLoadModelWithFallback:
+    def test_returns_successful_load_result(self):
+        from vllm_mlx.utils.tokenizer import load_model_with_fallback
+
+        fake_model = object()
+        fake_tokenizer = object()
+
+        with patch("mlx_lm.load", return_value=(fake_model, fake_tokenizer)) as load:
+            model, tokenizer = load_model_with_fallback("mlx-community/Qwen3.5-4B")
+
+        load.assert_called_once()
+        assert model is fake_model
+        assert tokenizer is fake_tokenizer
+
+    def test_uses_tokenizer_fallback_for_tokenizer_errors(self):
+        from vllm_mlx.utils.tokenizer import load_model_with_fallback
+
+        fake_model = object()
+        fake_tokenizer = object()
+
+        with patch(
+            "mlx_lm.load",
+            side_effect=ValueError("Tokenizer class Foo does not exist"),
+        ), patch(
+            "vllm_mlx.utils.tokenizer._load_with_tokenizer_fallback",
+            return_value=(fake_model, fake_tokenizer),
+        ) as fallback:
+            model, tokenizer = load_model_with_fallback("example/model")
+
+        fallback.assert_called_once_with("example/model")
+        assert model is fake_model
+        assert tokenizer is fake_tokenizer

--- a/vllm_mlx/utils/tokenizer.py
+++ b/vllm_mlx/utils/tokenizer.py
@@ -52,6 +52,7 @@ def load_model_with_fallback(model_name: str, tokenizer_config: dict = None):
 
     try:
         model, tokenizer = load(model_name, tokenizer_config=tokenizer_config)
+        return model, tokenizer
     except ValueError as e:
         # Fallback for models with non-standard tokenizers
         if "TokenizersBackend" in str(e) or "Tokenizer class" in str(e):


### PR DESCRIPTION
## Summary
- fix `load_model_with_fallback()` so successful `mlx_lm.load()` calls return the `(model, tokenizer)` tuple instead of falling through as `None`
- add regression coverage for the successful load path

## Why this is independently deployable
- pure loader bugfix
- no API, CLI, batching, or protocol behavior change
- useful regardless of whether the Responses work is merged

## Related context
This bug sits beneath several other Apple Silicon model-serving paths.

Relevant surrounding work in `waybarrios/vllm-mlx`:
- `#127` merged broader Qwen3.5 text support and streaming fixes: https://github.com/waybarrios/vllm-mlx/pull/127
- open hybrid/cache/runtime work continues in `#144`, `#160`, `#165`, `#183`, and `#194`: https://github.com/waybarrios/vllm-mlx/pull/144 https://github.com/waybarrios/vllm-mlx/pull/160 https://github.com/waybarrios/vllm-mlx/pull/165 https://github.com/waybarrios/vllm-mlx/pull/183 https://github.com/waybarrios/vllm-mlx/pull/194
- our fork’s separate hybrid-cache follow-up lives in `krystophny/vllm-mlx#6`: https://github.com/krystophny/vllm-mlx/pull/6

This PR deliberately stays below all of that and only fixes the successful return path.

## Validation
- `PYTHONPATH=/Users/ert/code/vllm-mlx /Users/ert/code/.venv/bin/python -m pytest tests/test_tokenizer_utils.py -q`
- `python3 -m compileall vllm_mlx`

## What could still improve
- broader loader-path coverage for strict/strict-false fallbacks and hybrid model families
- explicit end-to-end smoke tests for each benchmark model alias used by FortBench
