### PR TITLE
Add served model alias support

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -167,6 +167,27 @@ class TestCompletionRequest:
         assert request.max_tokens is None  # uses _default_max_tokens when None
 
 
+class TestServerCli:
+    """Test CLI argument parsing."""
+
+    def test_served_model_name_argument(self):
+        """Test that --served-model-name is accepted and parsed."""
+        from vllm_mlx.server import build_arg_parser
+
+        parser = build_arg_parser()
+        args = parser.parse_args(
+            [
+                "--model",
+                "mlx-community/Qwen3.5-4B-MLX-8bit",
+                "--served-model-name",
+                "qwen",
+            ]
+        )
+
+        assert args.model == "mlx-community/Qwen3.5-4B-MLX-8bit"
+        assert args.served_model_name == "qwen"
+
+
 # =============================================================================
 # Helper Function Tests
 # =============================================================================

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -2184,8 +2184,8 @@ async def init_mcp(config_path: str):
 # =============================================================================
 
 
-def main():
-    """Run the server."""
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser."""
     parser = argparse.ArgumentParser(
         description="vllm-mlx OpenAI-compatible server for LLM and MLLM inference",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -2206,6 +2206,12 @@ Examples:
         type=str,
         default="mlx-community/Llama-3.2-3B-Instruct-4bit",
         help="Model to load (HuggingFace model name or local path)",
+    )
+    parser.add_argument(
+        "--served-model-name",
+        type=str,
+        default=None,
+        help="Alias exposed via /v1/models and request validation",
     )
     parser.add_argument(
         "--host",
@@ -2291,6 +2297,12 @@ Examples:
         default=None,
         help="Default top_p for generation when not specified in request",
     )
+    return parser
+
+
+def main():
+    """Run the server."""
+    parser = build_arg_parser()
 
     args = parser.parse_args()
 
@@ -2348,6 +2360,7 @@ Examples:
         use_batching=args.continuous_batching,
         max_tokens=args.max_tokens,
         force_mllm=args.mllm,
+        served_model_name=args.served_model_name,
     )
 
     # Start server


### PR DESCRIPTION
## Summary
- add a dedicated `--served-model-name` server flag
- expose a stable alias via the existing `served_model_name` load path
- cover the new CLI option with parser tests

## Why this is deployable on its own
- it only changes how the server advertises and validates model names
- it does not require the Responses branch to remain useful
- it provides stable short aliases like `qwen` for local clients and benchmarks

## Testing
- `PYTHONPATH=/Users/ert/code/vllm-mlx /Users/ert/code/.venv/bin/python -m pytest tests/test_server.py -q`
- `python3 -m compileall vllm_mlx`
