### PR TITLE
Expose Harmony/GPT-OSS tool parser in serve CLI

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -167,6 +167,41 @@ class TestCompletionRequest:
         assert request.max_tokens is None  # uses _default_max_tokens when None
 
 
+class TestServeCli:
+    """Test serve CLI argument parsing."""
+
+    def test_tool_call_parser_accepts_harmony_aliases(self):
+        """GPT-OSS/Harmony parsers should be selectable from the serve CLI."""
+        from vllm_mlx.cli import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(
+            [
+                "serve",
+                "lmstudio-community/gpt-oss-20b-MLX-8bit",
+                "--enable-auto-tool-choice",
+                "--tool-call-parser",
+                "harmony",
+            ]
+        )
+
+        assert args.command == "serve"
+        assert args.tool_call_parser == "harmony"
+        assert args.enable_auto_tool_choice is True
+
+        args = parser.parse_args(
+            [
+                "serve",
+                "lmstudio-community/gpt-oss-20b-MLX-8bit",
+                "--enable-auto-tool-choice",
+                "--tool-call-parser",
+                "gpt-oss",
+            ]
+        )
+
+        assert args.tool_call_parser == "gpt-oss"
+
+
 # =============================================================================
 # Helper Function Tests
 # =============================================================================

--- a/vllm_mlx/cli.py
+++ b/vllm_mlx/cli.py
@@ -593,7 +593,8 @@ def bench_kv_cache_command(args):
     )
 
 
-def main():
+def create_parser() -> argparse.ArgumentParser:
+    """Build the top-level CLI parser."""
     parser = argparse.ArgumentParser(
         description="vllm-mlx: Apple Silicon MLX backend for vLLM",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -832,6 +833,8 @@ Examples:
             "qwen3_coder",
             "llama",
             "hermes",
+            "harmony",
+            "gpt-oss",
             "deepseek",
             "kimi",
             "granite",
@@ -843,7 +846,8 @@ Examples:
         help=(
             "Select the tool call parser for the model. Options: "
             "auto (auto-detect), mistral, qwen, qwen3_coder, llama, hermes, "
-            "deepseek, kimi, granite, nemotron, xlam, functionary, glm47. "
+            "harmony, gpt-oss, deepseek, kimi, granite, nemotron, xlam, "
+            "functionary, glm47. "
             "Required for --enable-auto-tool-choice."
         ),
     )
@@ -1022,6 +1026,12 @@ Examples:
         default=64,
         help="Quantization group size (default: 64)",
     )
+
+    return parser
+
+
+def main():
+    parser = create_parser()
 
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary
- expose `harmony` and `gpt-oss` as valid `--tool-call-parser` values for `vllm-mlx serve`
- factor CLI parser construction so the flag surface is unit-testable
- add regression tests proving the serve CLI accepts the parser choices already registered in code

## Why this is independently deployable
- CLI-only surface fix for already-registered parsers
- no batching, cache, scheduler, or API protocol change
- immediately useful for local GPT-OSS/Harmony tool-use without launcher-side hacks

## Related upstream context
In upstream `waybarrios/vllm-mlx`, the parser building blocks already exist:
- `#50` merged Harmony parser support: https://github.com/waybarrios/vllm-mlx/pull/50
- `#53` merged GPT-OSS reasoning parsing: https://github.com/waybarrios/vllm-mlx/pull/53

The gap this PR fixes is narrower: those parsers were registered, but the serve CLI did not expose them consistently via `--tool-call-parser`.

Related ongoing work around tool-choice / tool parsing behavior upstream:
- `#173` tool_choice=`none`: https://github.com/waybarrios/vllm-mlx/pull/173
- `#177` streaming reasoning branch tool parsing: https://github.com/waybarrios/vllm-mlx/pull/177
- `#210` follow-up tool_choice=`none`: https://github.com/waybarrios/vllm-mlx/pull/210
- `vllm#37433` Responses tool_choice for GPT-OSS/Harmony: https://github.com/vllm-project/vllm/pull/37433

This PR does not try to solve those behavioral questions. It only exposes the parser selections cleanly.

## Validation
- `PYTHONPATH=/Users/ert/code/vllm-mlx /Users/ert/code/.venv/bin/python -m pytest tests/test_server.py -q`
- `python3 -m compileall vllm_mlx`

## What could still improve
- end-to-end HTTP tests covering `--tool-call-parser harmony` and `--tool-call-parser gpt-oss`
- matrix tests covering parser selection plus `tool_choice=auto/none/required`
