### PR TITLE
Add Codex Responses prompt normalization

### DIFF
--- a/tests/test_responses_api.py
+++ b/tests/test_responses_api.py
@@ -112,6 +112,56 @@ class TestResponsesEndpoint:
         assert second_messages[2]["role"] == "user"
         assert second_messages[2]["content"] == "Follow-up prompt"
 
+    def test_developer_role_is_normalized_to_system(self, client):
+        import vllm_mlx.server as srv
+
+        engine = _mock_engine(_output("Ready"))
+        srv._engine = engine
+
+        resp = client.post(
+            "/v1/responses",
+            json={
+                "model": "test-model",
+                "input": [
+                    {"type": "message", "role": "user", "content": "Hi"},
+                    {"type": "message", "role": "developer", "content": "Be terse"},
+                ],
+            },
+        )
+
+        assert resp.status_code == 200
+        messages = engine.chat.call_args.kwargs["messages"]
+        assert messages[0]["role"] == "system"
+        assert messages[0]["content"] == "Be terse"
+        assert messages[1]["role"] == "user"
+        assert messages[1]["content"] == "Hi"
+
+    def test_instructions_and_developer_message_are_merged(self, client):
+        import vllm_mlx.server as srv
+
+        engine = _mock_engine(_output("Ready"))
+        srv._engine = engine
+
+        resp = client.post(
+            "/v1/responses",
+            json={
+                "model": "test-model",
+                "instructions": "System instructions",
+                "input": [
+                    {"type": "message", "role": "developer", "content": "Developer note"},
+                    {"type": "message", "role": "user", "content": "Hi"},
+                ],
+            },
+        )
+
+        assert resp.status_code == 200
+        messages = engine.chat.call_args.kwargs["messages"]
+        assert len([m for m in messages if m["role"] == "system"]) == 1
+        assert messages[0]["role"] == "system"
+        assert "System instructions" in messages[0]["content"]
+        assert "Developer note" in messages[0]["content"]
+        assert messages[1]["role"] == "user"
+
     def test_function_call_output_input_is_mapped_cleanly(self, client):
         import vllm_mlx.server as srv
 

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -538,9 +538,12 @@ def _responses_input_to_chat_messages(request: ResponsesRequest) -> list[dict]:
         if isinstance(item, dict):
             item_type = item.get("type", "")
             if item_type == "message":
+                role = item.get("role", "user")
+                if role == "developer":
+                    role = "system"
                 messages.append(
                     {
-                        "role": item.get("role", "user"),
+                        "role": role,
                         "content": _response_content_to_text(item.get("content")),
                     }
                 )
@@ -576,9 +579,12 @@ def _responses_input_to_chat_messages(request: ResponsesRequest) -> list[dict]:
             continue
 
         if isinstance(item, ResponseMessageItem):
+            role = item.role
+            if role == "developer":
+                role = "system"
             messages.append(
                 {
-                    "role": item.role,
+                    "role": role,
                     "content": _response_content_to_text(item.content),
                 }
             )
@@ -641,6 +647,19 @@ def _responses_request_to_chat_request(request: ResponsesRequest) -> ChatComplet
                 ),
             },
         )
+
+    system_messages = [msg for msg in messages if msg.get("role") == "system"]
+    non_system_messages = [msg for msg in messages if msg.get("role") != "system"]
+    merged_system_content = "\n\n".join(
+        str(msg.get("content", "")).strip()
+        for msg in system_messages
+        if str(msg.get("content", "")).strip()
+    )
+    messages = (
+        [{"role": "system", "content": merged_system_content}]
+        if merged_system_content
+        else []
+    ) + non_system_messages
 
     return ChatCompletionRequest(
         model=request.model,


### PR DESCRIPTION
## Summary
- normalize OpenAI Responses `developer` content into a single leading `system` message
- merge `instructions` with developer/system content in the shape Codex expects
- add targeted regression tests for Codex prompt compatibility on top of the Responses API core

## Stack position
- depends on `krystophny/vllm-mlx#1`: https://github.com/krystophny/vllm-mlx/pull/1
- intentionally does **not** change the core `/v1/responses` transport or persistence logic
- this is the client-compat layer needed for Codex local mode after the core endpoint exists

## Why this is independently deployable on top of #1
- only affects `/v1/responses`
- leaves chat/completions and Anthropic message paths alone
- makes the Codex-specific prompt normalization explicit instead of smuggling it into the core endpoint PR

## Related upstream context
### `ggml-org/llama.cpp`
This PR follows the same class of fix that already showed up in llama.cpp:
- `llama.cpp#20079` translated `developer -> system` and merged prompt pieces for Codex/template compatibility: https://github.com/ggml-org/llama.cpp/pull/20079
- `llama.cpp#18486` and `#19720` provide the broader Responses background there: https://github.com/ggml-org/llama.cpp/pull/18486 https://github.com/ggml-org/llama.cpp/pull/19720

### `vllm-project/vllm`
Related open Responses prompt/state fixes upstream include:
- `vllm#37727` instructions leaking with `previous_response_id`: https://github.com/vllm-project/vllm/pull/37727
- `vllm#37739` default chat-template kwargs handling in Responses: https://github.com/vllm-project/vllm/pull/37739

Our scope here is narrower: normalize the prompt shape so Codex local turns render cleanly against `vllm-mlx`.

## Validation
- `PYTHONPATH=/Users/ert/code/vllm-mlx /Users/ert/code/.venv/bin/python -m pytest tests/test_responses_api.py -q`
- local Codex validation against `vllm-mlx` in the FortBench MLX rerun

## What could still improve
- additional tests covering more Codex prompt combinations with `previous_response_id`
- explicit fixtures for unsupported built-in tools alongside Codex prompt normalization
- upstreaming once the core Responses PR shape settles
