### PR TITLE
fix: harden _validate_tool_calls against malformed tool defs and schemas

### DIFF
--- a/tests/test_tool_choice.py
+++ b/tests/test_tool_choice.py
@@ -431,6 +431,25 @@ class TestToolCallValidation:
         assert result is not None
         assert len(result) == 1
 
+    def test_malformed_tool_definition_skipped(self):
+        """Tool def dict missing 'name' key doesn't crash."""
+        tc = self._make_tool_call("get_weather", '{"city": "NYC"}')
+        tools = [
+            {"type": "function", "function": {"description": "no name field"}},
+            self._make_tool_def("get_weather"),
+        ]
+        result = srv._validate_tool_calls([tc], tools)
+        assert result is not None
+        assert len(result) == 1
+
+    def test_malformed_schema_drops_tool_call(self):
+        """Tool with invalid JSON Schema drops the call instead of crashing."""
+        tc = self._make_tool_call("bad_schema", '{"x": 1}')
+        bad_schema = {"type": "object", "properties": {"x": {"type": "nonexistent_type"}}}
+        tools = [self._make_tool_def("bad_schema", bad_schema)]
+        result = srv._validate_tool_calls([tc], tools)
+        assert result is None
+
 
 # ---------------------------------------------------------------------------
 # Integration test: invalid tool calls removed from API response

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -538,7 +538,9 @@ def _validate_tool_calls(
             else (t.get("function") if isinstance(t, dict) else None)
         )
         if func and isinstance(func, dict):
-            tools_by_name[func["name"]] = func.get("parameters")
+            fname = func.get("name")
+            if fname:
+                tools_by_name[fname] = func.get("parameters")
 
     valid = []
     for tc in tool_calls:
@@ -551,7 +553,7 @@ def _validate_tool_calls(
             try:
                 args = json.loads(tc.function.arguments)
                 jsonschema.validate(args, schema)
-            except (json.JSONDecodeError, jsonschema.ValidationError) as exc:
+            except (json.JSONDecodeError, jsonschema.ValidationError, jsonschema.SchemaError) as exc:
                 logger.warning(
                     "Dropping tool call %s: invalid arguments: %s", name, exc
                 )


### PR DESCRIPTION
## Summary
Fix two defensiveness gaps in `_validate_tool_calls()` found by Qodo review of PR #29:

1. **KeyError on malformed tool def**: Use `.get("name")` instead of `["name"]` so tool definitions missing a `name` key are skipped instead of crashing
2. **SchemaError not caught**: Catch `jsonschema.SchemaError` alongside `ValidationError` so malformed parameter schemas drop the tool call instead of 500ing the request

## Test plan
- `test_malformed_tool_definition_skipped`: tool def dict missing `name` key doesn't crash
- `test_malformed_schema_drops_tool_call`: invalid JSON Schema drops the call gracefully
- Full suite: 27 tool choice/validation tests pass