### PR TITLE
feat: grammar-constrained decoding via Outlines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,9 @@ vision = [
     "torchvision>=0.18.0",
 ]
 # Audio dependencies for TTS/STT (mlx-audio)
+guided = [
+    "outlines>=1.2.0",
+]
 audio = [
     "mlx-audio>=0.2.9",
     "sounddevice>=0.4.0",

--- a/tests/test_guided_decoding.py
+++ b/tests/test_guided_decoding.py
@@ -1,0 +1,187 @@
+"""Tests for grammar-constrained decoding via Outlines."""
+
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vllm_mlx import guided_decoding
+
+
+@pytest.fixture(autouse=True)
+def _reset_backend():
+    """Ensure each test starts with a clean backend state."""
+    original = guided_decoding._backend
+    guided_decoding._backend = None
+    yield
+    guided_decoding._backend = original
+
+
+class TestIsAvailable:
+    def test_false_when_not_initialized(self):
+        assert guided_decoding.is_available() is False
+
+    def test_true_when_backend_set(self):
+        guided_decoding._backend = MagicMock()
+        assert guided_decoding.is_available() is True
+
+
+class TestInitGuidedDecoding:
+    def test_graceful_when_outlines_missing(self):
+        with patch.dict(
+            sys.modules,
+            {
+                "outlines": None,
+                "outlines.models": None,
+                "outlines.models.mlxlm": None,
+                "outlines.backends": None,
+                "outlines.backends.outlines_core": None,
+            },
+        ):
+            guided_decoding.init_guided_decoding(MagicMock(), MagicMock())
+        assert guided_decoding._backend is None
+
+    def test_graceful_on_backend_error(self):
+        with patch(
+            "vllm_mlx.guided_decoding.MLXLM",
+            create=True,
+            side_effect=RuntimeError("model mismatch"),
+        ):
+            guided_decoding.init_guided_decoding(MagicMock(), MagicMock())
+        assert guided_decoding._backend is None
+
+
+class TestBuildJsonSchemaProcessor:
+    def test_returns_none_without_backend(self):
+        result = guided_decoding.build_json_schema_processor({"type": "object"})
+        assert result is None
+
+    def test_with_dict_schema(self):
+        mock_backend = MagicMock()
+        mock_processor = MagicMock()
+        mock_backend.get_json_schema_logits_processor.return_value = mock_processor
+        guided_decoding._backend = mock_backend
+
+        schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+        result = guided_decoding.build_json_schema_processor(schema)
+
+        assert result is mock_processor
+        mock_backend.get_json_schema_logits_processor.assert_called_once_with(
+            json.dumps(schema)
+        )
+
+    def test_with_string_schema(self):
+        mock_backend = MagicMock()
+        mock_backend.get_json_schema_logits_processor.return_value = MagicMock()
+        guided_decoding._backend = mock_backend
+
+        schema_str = '{"type": "object"}'
+        guided_decoding.build_json_schema_processor(schema_str)
+
+        mock_backend.get_json_schema_logits_processor.assert_called_once_with(
+            schema_str
+        )
+
+    def test_returns_none_on_error(self):
+        mock_backend = MagicMock()
+        mock_backend.get_json_schema_logits_processor.side_effect = Exception("bad")
+        guided_decoding._backend = mock_backend
+
+        result = guided_decoding.build_json_schema_processor({"type": "invalid"})
+        assert result is None
+
+
+class TestBuildRegexProcessor:
+    def test_returns_none_without_backend(self):
+        result = guided_decoding.build_regex_processor(r"\d+")
+        assert result is None
+
+    def test_with_mock_backend(self):
+        mock_backend = MagicMock()
+        mock_processor = MagicMock()
+        mock_backend.get_regex_logits_processor.return_value = mock_processor
+        guided_decoding._backend = mock_backend
+
+        result = guided_decoding.build_regex_processor(r"\d+")
+
+        assert result is mock_processor
+        mock_backend.get_regex_logits_processor.assert_called_once_with(r"\d+")
+
+    def test_returns_none_on_error(self):
+        mock_backend = MagicMock()
+        mock_backend.get_regex_logits_processor.side_effect = Exception("bad regex")
+        guided_decoding._backend = mock_backend
+
+        result = guided_decoding.build_regex_processor(r"[invalid")
+        assert result is None
+
+
+class TestBuildGuidedProcessorHelper:
+    """Tests for the server-side _build_guided_processor helper."""
+
+    def test_returns_none_for_no_format(self):
+        from vllm_mlx.server import _build_guided_processor
+
+        assert _build_guided_processor(None) is None
+
+    def test_returns_none_when_unavailable(self):
+        from vllm_mlx.server import _build_guided_processor
+
+        result = _build_guided_processor({"type": "json_schema", "json_schema": {"schema": {}}})
+        # Backend not initialized, so should return None
+        assert result is None
+
+    def test_returns_none_for_text_format(self):
+        from vllm_mlx.server import _build_guided_processor
+
+        guided_decoding._backend = MagicMock()
+        result = _build_guided_processor({"type": "text"})
+        assert result is None
+
+    def test_returns_none_for_json_object_format(self):
+        from vllm_mlx.server import _build_guided_processor
+
+        guided_decoding._backend = MagicMock()
+        result = _build_guided_processor({"type": "json_object"})
+        assert result is None
+
+    def test_delegates_to_build_json_schema_processor(self):
+        from vllm_mlx.server import _build_guided_processor
+
+        mock_processor = MagicMock()
+        mock_backend = MagicMock()
+        mock_backend.get_json_schema_logits_processor.return_value = mock_processor
+        guided_decoding._backend = mock_backend
+
+        schema = {"type": "object", "properties": {"x": {"type": "integer"}}}
+        rf = {
+            "type": "json_schema",
+            "json_schema": {"name": "test", "schema": schema},
+        }
+        result = _build_guided_processor(rf)
+
+        assert result is mock_processor
+        mock_backend.get_json_schema_logits_processor.assert_called_once_with(
+            json.dumps(schema)
+        )
+
+    def test_handles_pydantic_response_format(self):
+        from vllm_mlx.api.models import ResponseFormat, ResponseFormatJsonSchema
+        from vllm_mlx.server import _build_guided_processor
+
+        mock_processor = MagicMock()
+        mock_backend = MagicMock()
+        mock_backend.get_json_schema_logits_processor.return_value = mock_processor
+        guided_decoding._backend = mock_backend
+
+        schema = {"type": "object"}
+        rf = ResponseFormat(
+            type="json_schema",
+            json_schema=ResponseFormatJsonSchema(
+                name="test_schema",
+                **{"schema": schema},
+            ),
+        )
+        result = _build_guided_processor(rf)
+        assert result is mock_processor

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -880,6 +880,7 @@ class SimpleEngine(BaseEngine):
         specprefill_override = kwargs.pop("specprefill", None)
         specprefill_keep_pct = kwargs.pop("specprefill_keep_pct", None)
         chat_template_kwargs = dict(kwargs.pop("chat_template_kwargs", {}) or {})
+        logits_processors = kwargs.pop("logits_processors", None)
 
         # Read enable_thinking from env (set by runtime_patches, consistent with MLLM path)
         enable_thinking_env = os.environ.get("VLLM_MLX_ENABLE_THINKING", "true")
@@ -1103,6 +1104,12 @@ class SimpleEngine(BaseEngine):
                 )
 
             # --- SpecPrefill path (with fallback to normal on failure) ---
+            if use_specprefill and logits_processors:
+                logger.warning(
+                    "SpecPrefill does not support logits_processors; "
+                    "using normal MTP path"
+                )
+                use_specprefill = False
             if use_specprefill:
                 try:
                     return _run_specprefill(model, backbone_cache)
@@ -1134,6 +1141,8 @@ class SimpleEngine(BaseEngine):
             )
             if prompt_cache is not None:
                 gen_kwargs["prompt_cache"] = prompt_cache
+            if logits_processors:
+                gen_kwargs["logits_processors"] = logits_processors
 
             for resp in mlx_stream_generate(
                 model,

--- a/vllm_mlx/guided_decoding.py
+++ b/vllm_mlx/guided_decoding.py
@@ -1,0 +1,78 @@
+"""Grammar-constrained decoding via Outlines.
+
+Provides logits processors that constrain token generation to match a JSON
+schema or regex pattern. Uses Outlines' OutlinesCoreBackend which compiles
+grammars into efficient finite-state automata over the model's vocabulary.
+
+The backend is initialized once after model load and reused for all requests.
+When outlines is not installed, all functions degrade gracefully (returning
+None) so callers can fall back to prompt-injection-based structured output.
+"""
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_backend: Any = None
+
+
+def init_guided_decoding(model: Any, tokenizer: Any) -> None:
+    """Initialize the Outlines backend. Call once after model load."""
+    global _backend
+    try:
+        from outlines.backends.outlines_core import OutlinesCoreBackend
+        from outlines.models.mlxlm import MLXLM
+
+        outlines_model = MLXLM(model, tokenizer)
+        _backend = OutlinesCoreBackend(outlines_model)
+        logger.info("Guided decoding initialized (outlines backend)")
+    except ImportError:
+        logger.info("outlines not installed; guided decoding disabled")
+    except Exception:
+        logger.warning("Failed to initialize guided decoding", exc_info=True)
+
+
+def is_available() -> bool:
+    """Return True when the Outlines backend has been initialized."""
+    return _backend is not None
+
+
+def build_json_schema_processor(schema: dict | str) -> Any:
+    """Build a logits processor that constrains output to a JSON schema.
+
+    Args:
+        schema: JSON Schema as a dict or pre-serialized JSON string.
+
+    Returns:
+        A callable ``(input_ids, logits) -> logits`` suitable for mlx-lm's
+        ``logits_processors`` parameter, or None when outlines is unavailable.
+    """
+    if _backend is None:
+        return None
+    schema_str = json.dumps(schema) if isinstance(schema, dict) else schema
+    try:
+        return _backend.get_json_schema_logits_processor(schema_str)
+    except Exception:
+        logger.warning("Failed to build JSON schema processor", exc_info=True)
+        return None
+
+
+def build_regex_processor(pattern: str) -> Any:
+    """Build a logits processor that constrains output to a regex pattern.
+
+    Args:
+        pattern: Regular expression the generated text must match.
+
+    Returns:
+        A callable ``(input_ids, logits) -> logits`` suitable for mlx-lm's
+        ``logits_processors`` parameter, or None when outlines is unavailable.
+    """
+    if _backend is None:
+        return None
+    try:
+        return _backend.get_regex_logits_processor(pattern)
+    except Exception:
+        logger.warning("Failed to build regex processor", exc_info=True)
+        return None

--- a/vllm_mlx/models/llm.py
+++ b/vllm_mlx/models/llm.py
@@ -8,7 +8,7 @@ integrating with vLLM's model execution system.
 
 import logging
 from dataclasses import dataclass
-from typing import Iterator
+from typing import Any, Callable, Iterator
 
 logger = logging.getLogger(__name__)
 
@@ -127,6 +127,7 @@ class MLXLanguageModel:
         top_p: float = 0.9,
         repetition_penalty: float = 1.0,
         stop: list[str] | None = None,
+        logits_processors: list[Callable] | None = None,
     ) -> GenerationOutput:
         """
         Generate text from a prompt.
@@ -138,6 +139,7 @@ class MLXLanguageModel:
             top_p: Top-p (nucleus) sampling parameter
             repetition_penalty: Penalty for repeating tokens
             stop: List of stop sequences
+            logits_processors: Callables that transform logits before sampling
 
         Returns:
             GenerationOutput with generated text and tokens
@@ -150,6 +152,10 @@ class MLXLanguageModel:
         # Create sampler with parameters
         sampler = self._create_sampler(temperature, top_p)
 
+        gen_kwargs: dict[str, Any] = {}
+        if logits_processors:
+            gen_kwargs["logits_processors"] = logits_processors
+
         # Generate text
         output_text = generate(
             self.model,
@@ -158,6 +164,7 @@ class MLXLanguageModel:
             max_tokens=max_tokens,
             sampler=sampler,
             verbose=False,
+            **gen_kwargs,
         )
 
         # Tokenize output to get token IDs
@@ -180,6 +187,7 @@ class MLXLanguageModel:
         top_p: float = 0.9,
         repetition_penalty: float = 1.0,
         stop: list[str] | None = None,
+        logits_processors: list[Callable] | None = None,
     ) -> Iterator[StreamingOutput]:
         """
         Stream text generation token by token.
@@ -191,6 +199,7 @@ class MLXLanguageModel:
             top_p: Top-p (nucleus) sampling parameter
             repetition_penalty: Penalty for repeating tokens
             stop: List of stop sequences
+            logits_processors: Callables that transform logits before sampling
 
         Yields:
             StreamingOutput for each generated token
@@ -206,9 +215,11 @@ class MLXLanguageModel:
         token_count = 0
         accumulated_text = ""
 
-        mtp_kwargs = {}
+        gen_kwargs: dict[str, Any] = {}
         if self._mtp:
-            mtp_kwargs["mtp"] = True
+            gen_kwargs["mtp"] = True
+        if logits_processors:
+            gen_kwargs["logits_processors"] = logits_processors
 
         for response in stream_generate(
             self.model,
@@ -216,7 +227,7 @@ class MLXLanguageModel:
             prompt=prompt,
             max_tokens=max_tokens,
             sampler=sampler,
-            **mtp_kwargs,
+            **gen_kwargs,
         ):
             token_count += 1
             # response.text is the new token text (not accumulated)

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -1596,6 +1596,16 @@ def load_model(
     if _engine.preserve_native_tool_format:
         logger.info(f"Native tool format enabled for parser: {_tool_call_parser}")
 
+    # Initialize grammar-constrained decoding (Outlines) if the engine
+    # exposes a raw model and tokenizer (SimpleEngine only for now).
+    if hasattr(_engine, "_model") and _engine._model is not None:
+        raw_model = getattr(_engine._model, "model", None)
+        raw_tokenizer = getattr(_engine._model, "tokenizer", None)
+        if raw_model is not None and raw_tokenizer is not None:
+            from .guided_decoding import init_guided_decoding
+
+            init_guided_decoding(raw_model, raw_tokenizer)
+
     logger.info(f"Default max tokens: {_default_max_tokens}")
 
 
@@ -2440,6 +2450,10 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
             # Inject JSON instruction into messages
             messages = _inject_json_instruction(messages, json_instruction)
 
+    # Build guided-decoding logits processor when a JSON schema is provided.
+    # Falls back to prompt injection + post-hoc validation when unavailable.
+    guided_processor = _build_guided_processor(response_format)
+
     # Prepare kwargs
     chat_kwargs = {
         "max_tokens": request.max_tokens or _default_max_tokens,
@@ -2470,6 +2484,9 @@ async def create_chat_completion(request: ChatCompletionRequest, raw_request: Re
     should_parse_tools = _apply_tool_choice(
         request.tool_choice, chat_kwargs, messages
     )
+
+    if guided_processor is not None:
+        chat_kwargs["logits_processors"] = [guided_processor]
 
     if request.stream:
         return StreamingResponse(
@@ -2572,6 +2589,45 @@ async def create_response(request: ResponsesRequest, raw_request: Request):
         return Response(status_code=499)
 
     return response_object
+
+
+def _build_guided_processor(response_format):
+    """Extract a JSON schema from response_format and build a logits processor.
+
+    Returns None when guided decoding is unavailable or the format does not
+    contain a ``json_schema`` with an embedded ``schema``.
+    """
+    if not response_format:
+        return None
+
+    from .guided_decoding import build_json_schema_processor, is_available
+
+    if not is_available():
+        return None
+
+    # Normalize to dict
+    if hasattr(response_format, "model_dump"):
+        rf = response_format.model_dump(by_alias=True)
+    elif isinstance(response_format, dict):
+        rf = response_format
+    else:
+        return None
+
+    if rf.get("type") != "json_schema":
+        return None
+
+    js = rf.get("json_schema")
+    if not isinstance(js, dict):
+        return None
+
+    schema = js.get("schema")
+    if schema is None:
+        return None
+
+    processor = build_json_schema_processor(schema)
+    if processor is not None:
+        logger.info("Guided decoding: using Outlines logits processor for JSON schema")
+    return processor
 
 
 def _inject_json_instruction(messages: list, instruction: str) -> list:


### PR DESCRIPTION
## Summary

Add grammar-constrained decoding via Outlines logits processors. When `response_format` specifies a JSON schema, build a logits processor that constrains every token to produce schema-valid output. Falls back to prompt injection when outlines is not installed. Fixes #25.

## What changed

- NEW `vllm_mlx/guided_decoding.py`: thin wrapper over Outlines' `OutlinesCoreBackend`
- `server.py`: initialize backend at startup, build guided processor for `json_schema` response_format, pass via `chat_kwargs["logits_processors"]`
- `models/llm.py`: forward `logits_processors` kwarg to `mlx_lm.generate`/`stream_generate`
- `engine/simple.py`: forward `logits_processors` in MTP text path; disable specprefill when logits_processors are active (specprefill has its own sampling loop that can't apply processors)
- `pyproject.toml`: add `[guided]` optional dependency group

## Verification

### New tests pass on branch
```
$ python -m pytest tests/test_guided_decoding.py -v
17 passed
```

### Full suite
```
$ python -m pytest tests/ -v --timeout=120
1018 passed, 9 skipped
```

## Test plan
- [x] Unit tests for all guided_decoding module functions
- [x] Unit tests for server _build_guided_processor helper
- [x] Verify graceful degradation when outlines not installed
- [x] Verify specprefill is bypassed when logits_processors active
- [ ] Manual end-to-end test with loaded model and json_schema response_format