### PR TITLE
feat: grammar-constrained tool calling for required/named tool_choice

### DIFF
--- a/tests/test_guided_decoding.py
+++ b/tests/test_guided_decoding.py
@@ -185,3 +185,106 @@ class TestBuildGuidedProcessorHelper:
         )
         result = _build_guided_processor(rf)
         assert result is mock_processor
+
+
+# ---------------------------------------------------------------------------
+# Tests for build_tool_call_processor
+# ---------------------------------------------------------------------------
+
+
+class TestBuildToolCallProcessor:
+    """Unit tests for build_tool_call_processor()."""
+
+    def test_returns_none_without_backend(self):
+        guided_decoding._backend = None
+        result = guided_decoding.build_tool_call_processor(
+            [{"function": {"name": "f", "parameters": {"type": "object"}}}]
+        )
+        assert result is None
+
+    def test_returns_none_for_empty_tools(self):
+        guided_decoding._backend = MagicMock()
+        result = guided_decoding.build_tool_call_processor([])
+        assert result is None
+        guided_decoding._backend = None
+
+    def test_single_tool_schema(self):
+        mock_backend = MagicMock()
+        mock_processor = MagicMock()
+        mock_backend.get_json_schema_logits_processor.return_value = mock_processor
+        guided_decoding._backend = mock_backend
+
+        tools = [
+            {
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                }
+            }
+        ]
+        result = guided_decoding.build_tool_call_processor(tools)
+        assert result is mock_processor
+
+        # Verify the schema passed to the backend
+        call_args = mock_backend.get_json_schema_logits_processor.call_args[0][0]
+        schema = json.loads(call_args)
+        assert schema["properties"]["name"]["const"] == "get_weather"
+        assert schema["properties"]["arguments"]["properties"]["city"]["type"] == "string"
+        assert schema["required"] == ["name", "arguments"]
+        guided_decoding._backend = None
+
+    def test_multiple_tools_anyof(self):
+        mock_backend = MagicMock()
+        mock_backend.get_json_schema_logits_processor.return_value = MagicMock()
+        guided_decoding._backend = mock_backend
+
+        tools = [
+            {"function": {"name": "get_weather", "parameters": {"type": "object"}}},
+            {"function": {"name": "search", "parameters": {"type": "object"}}},
+        ]
+        result = guided_decoding.build_tool_call_processor(tools)
+        assert result is not None
+
+        call_args = mock_backend.get_json_schema_logits_processor.call_args[0][0]
+        schema = json.loads(call_args)
+        assert "anyOf" in schema
+        assert len(schema["anyOf"]) == 2
+        names = [s["properties"]["name"]["const"] for s in schema["anyOf"]]
+        assert "get_weather" in names
+        assert "search" in names
+        guided_decoding._backend = None
+
+    def test_tool_without_parameters(self):
+        mock_backend = MagicMock()
+        mock_backend.get_json_schema_logits_processor.return_value = MagicMock()
+        guided_decoding._backend = mock_backend
+
+        tools = [{"function": {"name": "ping"}}]
+        result = guided_decoding.build_tool_call_processor(tools)
+        assert result is not None
+
+        call_args = mock_backend.get_json_schema_logits_processor.call_args[0][0]
+        schema = json.loads(call_args)
+        assert schema["properties"]["arguments"]["type"] == "object"
+        guided_decoding._backend = None
+
+    def test_malformed_tool_skipped(self):
+        mock_backend = MagicMock()
+        mock_backend.get_json_schema_logits_processor.return_value = MagicMock()
+        guided_decoding._backend = mock_backend
+
+        tools = [
+            {"function": {"description": "no name"}},  # malformed
+            {"function": {"name": "valid"}},
+        ]
+        result = guided_decoding.build_tool_call_processor(tools)
+        assert result is not None
+
+        call_args = mock_backend.get_json_schema_logits_processor.call_args[0][0]
+        schema = json.loads(call_args)
+        assert schema["properties"]["name"]["const"] == "valid"
+        guided_decoding._backend = None

--- a/tests/test_tool_choice.py
+++ b/tests/test_tool_choice.py
@@ -104,6 +104,38 @@ class TestApplyToolChoice:
         assert messages[-1]["role"] == "system"
         assert "MUST call" in messages[-1]["content"]
 
+    def test_required_sets_logits_processors_when_guided_available(self):
+        from unittest.mock import MagicMock, patch
+
+        mock_processor = MagicMock()
+        chat_kwargs = {
+            "tools": [{"function": {"name": "f", "parameters": {"type": "object"}}}]
+        }
+        messages = [{"role": "user", "content": "hi"}]
+        with patch(
+            "vllm_mlx.guided_decoding.build_tool_call_processor",
+            return_value=mock_processor,
+        ):
+            srv._apply_tool_choice("required", chat_kwargs, messages)
+        assert chat_kwargs.get("logits_processors") == [mock_processor]
+
+    def test_named_function_sets_logits_processors_when_guided_available(self):
+        from unittest.mock import MagicMock, patch
+
+        mock_processor = MagicMock()
+        chat_kwargs = {
+            "tools": [{"function": {"name": "get_weather", "parameters": {"type": "object"}}}]
+        }
+        messages = [{"role": "user", "content": "hi"}]
+        with patch(
+            "vllm_mlx.guided_decoding.build_tool_call_processor",
+            return_value=mock_processor,
+        ):
+            srv._apply_tool_choice(
+                {"function": {"name": "get_weather"}}, chat_kwargs, messages
+            )
+        assert chat_kwargs.get("logits_processors") == [mock_processor]
+
     def test_dict_filters_tools_and_adds_system_message(self):
         chat_kwargs = {
             "tools": [

--- a/vllm_mlx/guided_decoding.py
+++ b/vllm_mlx/guided_decoding.py
@@ -76,3 +76,41 @@ def build_regex_processor(pattern: str) -> Any:
     except Exception:
         logger.warning("Failed to build regex processor", exc_info=True)
         return None
+
+
+def build_tool_call_processor(tools: list) -> Any:
+    """Build a logits processor for tool call JSON bodies.
+
+    Creates a JSON schema matching ``{"name": "...", "arguments": {...}}``
+    where *name* is constrained to declared tool names and *arguments*
+    conform to each tool's parameter schema.  Returns None when outlines
+    is unavailable or the tools list is empty.
+    """
+    if _backend is None or not tools:
+        return None
+
+    tool_schemas = []
+    for t in tools:
+        func = t.get("function", t) if isinstance(t, dict) else getattr(t, "function", None)
+        if not func or not isinstance(func, dict):
+            continue
+        name = func.get("name")
+        if not name:
+            continue
+        params = func.get("parameters", {"type": "object"})
+        tool_schemas.append(
+            {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "const": name},
+                    "arguments": params,
+                },
+                "required": ["name", "arguments"],
+            }
+        )
+
+    if not tool_schemas:
+        return None
+
+    schema = tool_schemas[0] if len(tool_schemas) == 1 else {"anyOf": tool_schemas}
+    return build_json_schema_processor(schema)

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -477,6 +477,11 @@ def _apply_tool_choice(
                 ),
             }
         )
+        from .guided_decoding import build_tool_call_processor
+
+        processor = build_tool_call_processor(chat_kwargs.get("tools", []))
+        if processor:
+            chat_kwargs["logits_processors"] = [processor]
         return True
 
     if isinstance(tool_choice, dict):
@@ -498,6 +503,11 @@ def _apply_tool_choice(
                             "content": f"You MUST call the function: {fname}",
                         }
                     )
+                    from .guided_decoding import build_tool_call_processor
+
+                    processor = build_tool_call_processor(filtered)
+                    if processor:
+                        chat_kwargs["logits_processors"] = [processor]
                     return True
             # Named function not found in tools — fall back to auto
             logger.warning(


### PR DESCRIPTION
## Summary

When `tool_choice="required"` or a named function, compile tool parameter schemas into a JSON schema and build an Outlines logits processor that constrains generation to produce valid tool call JSON. Falls back to system message hints when outlines is not available. Fixes #26.

Builds on #31 (guided decoding infrastructure).

## What changed

- `guided_decoding.py`: new `build_tool_call_processor(tools)` that creates `{"name": {"const": "func_name"}, "arguments": {schema}}` and returns a logits processor
- `server.py`: `_apply_tool_choice()` now sets `chat_kwargs["logits_processors"]` for required/named modes
- Tests: 8 new tests (6 unit for processor building, 2 for server wiring)

## Test plan
```
$ python -m pytest tests/test_guided_decoding.py tests/test_tool_choice.py -v
52 passed
```