### PR TITLE
feat: lazy grammar triggers for tool_choice=auto

### DIFF
--- a/tests/test_guided_decoding.py
+++ b/tests/test_guided_decoding.py
@@ -4,9 +4,11 @@ import json
 import sys
 from unittest.mock import MagicMock, patch
 
+import mlx.core as mx
 import pytest
 
 from vllm_mlx import guided_decoding
+from vllm_mlx.guided_decoding import LazyToolCallProcessor
 
 
 @pytest.fixture(autouse=True)
@@ -288,3 +290,111 @@ class TestBuildToolCallProcessor:
         schema = json.loads(call_args)
         assert schema["properties"]["name"]["const"] == "valid"
         guided_decoding._backend = None
+
+
+# ---------------------------------------------------------------------------
+# Tests for LazyToolCallProcessor
+# ---------------------------------------------------------------------------
+
+TRIGGER = 151657
+END = 151658
+
+
+class TestLazyToolCallProcessor:
+    """Unit tests for the lazy grammar trigger wrapper."""
+
+    def _make_processor(self, prefix_skip=1):
+        inner = MagicMock()
+        inner.return_value = mx.array([0.0, 1.0, 0.0])
+        return LazyToolCallProcessor(
+            inner=inner,
+            trigger_tokens=frozenset({TRIGGER}),
+            end_tokens=frozenset({END}),
+            prefix_skip=prefix_skip,
+        ), inner
+
+    def test_inactive_passthrough(self):
+        proc, inner = self._make_processor()
+        logits = mx.array([0.5, 0.5, 0.5])
+        result = proc(mx.array([100, 200, 300]), logits)
+        assert mx.array_equal(result, logits)
+        inner.assert_not_called()
+
+    def test_activates_on_trigger_no_prefix(self):
+        proc, inner = self._make_processor(prefix_skip=0)
+        logits = mx.array([0.5, 0.5, 0.5])
+        # Trigger token: transitions to ACTIVE, but logits pass through
+        result1 = proc(mx.array([100, TRIGGER]), logits)
+        assert mx.array_equal(result1, logits)
+        # Next token: ACTIVE, inner called
+        proc(mx.array([100, TRIGGER, 4913]), logits)
+        inner.assert_called_once()
+
+    def test_deactivates_on_end_token(self):
+        proc, inner = self._make_processor(prefix_skip=0)
+        logits = mx.array([0.5, 0.5, 0.5])
+        proc(mx.array([TRIGGER]), logits)  # trigger
+        proc(mx.array([TRIGGER, 4913]), logits)  # active, inner called
+        # End token: deactivates, logits pass through
+        result = proc(mx.array([TRIGGER, 4913, END]), logits)
+        assert mx.array_equal(result, logits)
+        # Next token: inactive again
+        inner.reset_mock()
+        result = proc(mx.array([TRIGGER, 4913, END, 200]), logits)
+        assert mx.array_equal(result, logits)
+        inner.assert_not_called()
+
+    def test_rearms_after_deactivation(self):
+        proc, inner = self._make_processor(prefix_skip=0)
+        logits = mx.array([0.5, 0.5, 0.5])
+        # First tool call cycle
+        proc(mx.array([TRIGGER]), logits)
+        proc(mx.array([TRIGGER, 4913]), logits)
+        proc(mx.array([TRIGGER, 4913, END]), logits)
+        # Second trigger re-arms
+        proc(mx.array([TRIGGER, 4913, END, TRIGGER]), logits)
+        # inner.reset called at least twice (once per trigger)
+        assert inner.reset.call_count >= 2
+
+    def test_prefix_skip(self):
+        proc, inner = self._make_processor(prefix_skip=2)
+        logits = mx.array([0.5, 0.5, 0.5])
+        proc(mx.array([TRIGGER]), logits)  # trigger -> PENDING
+        proc(mx.array([TRIGGER, 198]), logits)  # prefix 1, still PENDING
+        inner.assert_not_called()
+        proc(mx.array([TRIGGER, 198, 198]), logits)  # prefix 2 -> ACTIVE
+        inner.assert_not_called()  # transition step, not yet called
+        proc(mx.array([TRIGGER, 198, 198, 4913]), logits)  # ACTIVE, inner called
+        inner.assert_called()
+
+    def test_reset_returns_to_inactive(self):
+        proc, inner = self._make_processor(prefix_skip=0)
+        logits = mx.array([0.5, 0.5, 0.5])
+        proc(mx.array([TRIGGER]), logits)  # activate
+        proc.reset()
+        # After reset, should be inactive
+        result = proc(mx.array([100, 200]), logits)
+        assert mx.array_equal(result, logits)
+        # inner.reset called by both trigger and explicit reset
+        assert inner.reset.call_count >= 1
+
+    def test_build_lazy_returns_none_without_backend(self):
+        guided_decoding._backend = None
+        result = guided_decoding.build_lazy_tool_call_processor(
+            tools=[{"function": {"name": "f"}}],
+            trigger_tokens=frozenset({TRIGGER}),
+            end_tokens=frozenset({END}),
+        )
+        assert result is None
+
+    def test_build_lazy_returns_processor_with_backend(self):
+        mock_backend = MagicMock()
+        mock_backend.get_json_schema_logits_processor.return_value = MagicMock()
+        guided_decoding._backend = mock_backend
+        result = guided_decoding.build_lazy_tool_call_processor(
+            tools=[{"function": {"name": "f", "parameters": {"type": "object"}}}],
+            trigger_tokens=frozenset({TRIGGER}),
+            end_tokens=frozenset({END}),
+            prefix_skip=1,
+        )
+        assert isinstance(result, LazyToolCallProcessor)

--- a/tests/test_tool_choice.py
+++ b/tests/test_tool_choice.py
@@ -183,6 +183,51 @@ class TestApplyToolChoice:
         assert "tools" in chat_kwargs
         assert len(messages) == 1
 
+    def test_auto_with_triggers_sets_lazy_processor(self):
+        from unittest.mock import MagicMock, PropertyMock, patch
+
+        mock_processor = MagicMock()
+        chat_kwargs = {"tools": [{"function": {"name": "f"}}]}
+        messages = [{"role": "user", "content": "hi"}]
+
+        mock_parser = MagicMock()
+        type(mock_parser).TRIGGER_TOKEN_IDS = PropertyMock(
+            return_value=frozenset({151657})
+        )
+        type(mock_parser).END_TOKEN_IDS = PropertyMock(
+            return_value=frozenset({151658})
+        )
+        type(mock_parser).PREFIX_SKIP_TOKENS = PropertyMock(return_value=1)
+
+        with patch.object(srv, "_tool_call_parser", "qwen"), patch.object(
+            srv, "_tool_parser_instance", mock_parser
+        ), patch(
+            "vllm_mlx.guided_decoding.build_lazy_tool_call_processor",
+            return_value=mock_processor,
+        ):
+            result = srv._apply_tool_choice("auto", chat_kwargs, messages)
+
+        assert result is True
+        assert chat_kwargs.get("logits_processors") == [mock_processor]
+
+    def test_auto_without_triggers_no_processor(self):
+        from unittest.mock import MagicMock, PropertyMock, patch
+
+        chat_kwargs = {"tools": [{"function": {"name": "f"}}]}
+        messages = [{"role": "user", "content": "hi"}]
+
+        mock_parser = MagicMock()
+        type(mock_parser).TRIGGER_TOKEN_IDS = PropertyMock(
+            return_value=frozenset()
+        )
+
+        with patch.object(srv, "_tool_call_parser", "hermes"), patch.object(
+            srv, "_tool_parser_instance", mock_parser
+        ):
+            srv._apply_tool_choice("auto", chat_kwargs, messages)
+
+        assert "logits_processors" not in chat_kwargs
+
 
 # ---------------------------------------------------------------------------
 # Integration tests via the OpenAI chat endpoint

--- a/vllm_mlx/engine/simple.py
+++ b/vllm_mlx/engine/simple.py
@@ -1060,7 +1060,7 @@ class SimpleEngine(BaseEngine):
 
         # Run all Metal ops in a single serialized thread.
         def _run_all():
-            nonlocal backbone_cache, prompt_to_send
+            nonlocal backbone_cache, prompt_to_send, use_specprefill
 
             model = self._text_model
 

--- a/vllm_mlx/guided_decoding.py
+++ b/vllm_mlx/guided_decoding.py
@@ -114,3 +114,92 @@ def build_tool_call_processor(tools: list) -> Any:
 
     schema = tool_schemas[0] if len(tool_schemas) == 1 else {"anyOf": tool_schemas}
     return build_json_schema_processor(schema)
+
+
+# ---------------------------------------------------------------------------
+# Lazy grammar triggers for tool_choice=auto
+# ---------------------------------------------------------------------------
+
+_INACTIVE = 0
+_PENDING = 1
+_ACTIVE = 2
+
+
+class LazyToolCallProcessor:
+    """Logits processor that activates grammar constraints lazily.
+
+    Stays inactive (passes logits through) until the model emits a trigger
+    token (e.g., ``<tool_call>``). Then activates the inner grammar-constrained
+    processor for the JSON body. Deactivates on the end token (e.g.,
+    ``</tool_call>``) and re-arms for the next tool call.
+
+    Shape contract: mlx_lm's ``generate_step`` passes 1D ``input_ids``
+    ``(seq_len,)`` and 1D ``logits`` ``(vocab_size,)``. The inner Outlines
+    processor normalizes to 2D internally via its own ``__call__``.
+    """
+
+    def __init__(
+        self,
+        inner: Any,
+        trigger_tokens: frozenset[int],
+        end_tokens: frozenset[int],
+        prefix_skip: int = 0,
+    ):
+        self._inner = inner
+        self._trigger_tokens = trigger_tokens
+        self._end_tokens = end_tokens
+        self._prefix_skip = prefix_skip
+        self._state = _INACTIVE
+        self._prefix_remaining = 0
+        self._activation_index = 0
+
+    def __call__(self, input_ids: Any, logits: Any) -> Any:
+        import mlx.core as mx
+
+        last_token = input_ids[-1].item()
+
+        if self._state == _INACTIVE:
+            if last_token in self._trigger_tokens:
+                self._state = _PENDING if self._prefix_skip > 0 else _ACTIVE
+                self._prefix_remaining = self._prefix_skip
+                self._inner.reset()
+                self._activation_index = len(input_ids)
+            return logits
+
+        if self._state == _PENDING:
+            self._prefix_remaining -= 1
+            if self._prefix_remaining <= 0:
+                self._state = _ACTIVE
+                self._activation_index = len(input_ids)
+            return logits
+
+        # _ACTIVE
+        if last_token in self._end_tokens:
+            self._state = _INACTIVE
+            return logits
+
+        active_ids = input_ids[self._activation_index:]
+        return self._inner(active_ids, logits)
+
+    def reset(self) -> None:
+        """Reset to inactive state for a new generation."""
+        self._state = _INACTIVE
+        self._prefix_remaining = 0
+        self._activation_index = 0
+        self._inner.reset()
+
+
+def build_lazy_tool_call_processor(
+    tools: list,
+    trigger_tokens: frozenset[int],
+    end_tokens: frozenset[int],
+    prefix_skip: int = 0,
+) -> Any:
+    """Build a lazy tool call processor that activates on trigger tokens.
+
+    Returns None when the Outlines backend is unavailable or tools are empty.
+    """
+    inner = build_tool_call_processor(tools)
+    if inner is None:
+        return None
+    return LazyToolCallProcessor(inner, trigger_tokens, end_tokens, prefix_skip)

--- a/vllm_mlx/guided_decoding.py
+++ b/vllm_mlx/guided_decoding.py
@@ -154,8 +154,6 @@ class LazyToolCallProcessor:
         self._activation_index = 0
 
     def __call__(self, input_ids: Any, logits: Any) -> Any:
-        import mlx.core as mx
-
         last_token = input_ids[-1].item()
 
         if self._state == _INACTIVE:

--- a/vllm_mlx/server.py
+++ b/vllm_mlx/server.py
@@ -516,7 +516,20 @@ def _apply_tool_choice(
             )
         return True
 
-    # "auto" or None — no changes needed
+    # "auto" or None — build lazy grammar processor when triggers are defined
+    if chat_kwargs.get("tools") and _tool_call_parser and _tool_parser_instance:
+        parser_cls = type(_tool_parser_instance)
+        if parser_cls.TRIGGER_TOKEN_IDS:
+            from .guided_decoding import build_lazy_tool_call_processor
+
+            processor = build_lazy_tool_call_processor(
+                tools=chat_kwargs.get("tools", []),
+                trigger_tokens=parser_cls.TRIGGER_TOKEN_IDS,
+                end_tokens=parser_cls.END_TOKEN_IDS,
+                prefix_skip=parser_cls.PREFIX_SKIP_TOKENS,
+            )
+            if processor:
+                chat_kwargs["logits_processors"] = [processor]
     return True
 
 

--- a/vllm_mlx/tool_parsers/abstract_tool_parser.py
+++ b/vllm_mlx/tool_parsers/abstract_tool_parser.py
@@ -50,6 +50,17 @@ class ToolParser(ABC):
     # without needing conversion to text format.
     SUPPORTS_NATIVE_TOOL_FORMAT: bool = False
 
+    # Token IDs that signal the start of a tool call (e.g., <tool_call>).
+    # When non-empty, enables lazy grammar activation for tool_choice=auto.
+    TRIGGER_TOKEN_IDS: frozenset[int] = frozenset()
+
+    # Token IDs that signal the end of a tool call (e.g., </tool_call>).
+    END_TOKEN_IDS: frozenset[int] = frozenset()
+
+    # Number of tokens to skip between the trigger and JSON body (e.g., a
+    # newline between <tool_call> and the opening brace).
+    PREFIX_SKIP_TOKENS: int = 0
+
     @classmethod
     def supports_native_format(cls) -> bool:
         """

--- a/vllm_mlx/tool_parsers/qwen_tool_parser.py
+++ b/vllm_mlx/tool_parsers/qwen_tool_parser.py
@@ -37,6 +37,10 @@ class QwenToolParser(ToolParser):
     Used when --enable-auto-tool-choice --tool-call-parser qwen are set.
     """
 
+    TRIGGER_TOKEN_IDS: frozenset[int] = frozenset({151657})  # <tool_call>
+    END_TOKEN_IDS: frozenset[int] = frozenset({151658})  # </tool_call>
+    PREFIX_SKIP_TOKENS: int = 1  # \n between tag and JSON body
+
     # Pattern for XML-style: <tool_call>{"json"}</tool_call>
     XML_PATTERN = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
 


### PR DESCRIPTION
## Summary

- Add `LazyToolCallProcessor` in `guided_decoding.py` -- a stateful logits processor wrapper that stays inactive during free text and activates grammar constraints only when the model emits a tool call trigger token (e.g., `<tool_call>` token ID 151657 for Qwen). Deactivates on the end token (`</tool_call>`) and re-arms for subsequent tool calls in the same generation.
- Add trigger token constants to `ToolParser` base class (`TRIGGER_TOKEN_IDS`, `END_TOKEN_IDS`, `PREFIX_SKIP_TOKENS`) and set Qwen-specific values in `QwenToolParser`.
- Wire lazy processor into `_apply_tool_choice()` auto/None branch in `server.py` -- when tools are provided and the parser defines trigger tokens, a lazy processor is attached automatically.
- Fix `UnboundLocalError` in `_stream_generate_text._run_all` where `use_specprefill` was written without `nonlocal` declaration.

Fixes #27.

## Verification

### Test fails on main
```
$ git checkout origin/main
$ python -m pytest tests/test_guided_decoding.py::TestLazyToolCallProcessor -v
ERRORS - collected 0 items / 1 error (ImportError: cannot import name 'LazyToolCallProcessor')
$ python -m pytest tests/test_chat_template_kwargs.py::test_simple_engine_stream_generate_text_applies_chat_template_kwargs -v
FAILED - UnboundLocalError: cannot access local variable 'use_specprefill'
```

### Test passes after fix
```
$ git checkout feat/lazy-grammar-triggers
$ python -m pytest tests/test_guided_decoding.py tests/test_tool_choice.py -v
62 passed in 2.84s
$ python -m pytest tests/ -v --timeout=120
1072 passed, 9 skipped, 20 deselected in 27.62s
```

## Test plan

- [x] `TestLazyToolCallProcessor::test_inactive_passthrough` -- logits pass through when no trigger seen
- [x] `TestLazyToolCallProcessor::test_activates_on_trigger_no_prefix` -- inner processor called after trigger
- [x] `TestLazyToolCallProcessor::test_deactivates_on_end_token` -- returns to inactive on end token
- [x] `TestLazyToolCallProcessor::test_rearms_after_deactivation` -- re-arms for second tool call
- [x] `TestLazyToolCallProcessor::test_prefix_skip` -- skips N tokens between trigger and JSON body
- [x] `TestLazyToolCallProcessor::test_reset_returns_to_inactive` -- explicit reset works
- [x] `TestLazyToolCallProcessor::test_build_lazy_returns_none_without_backend` -- graceful degradation
- [x] `TestLazyToolCallProcessor::test_build_lazy_returns_processor_with_backend` -- factory works
- [x] `TestApplyToolChoice::test_auto_with_triggers_sets_lazy_processor` -- auto wiring works
- [x] `TestApplyToolChoice::test_auto_without_triggers_no_processor` -- no processor for parsers without triggers
- [x] `test_simple_engine_stream_generate_text_applies_chat_template_kwargs` -- use_specprefill nonlocal fix